### PR TITLE
Corrige link do Tchelinux para o LinkedIn.

### DIFF
--- a/tchelinux/template.json
+++ b/tchelinux/template.json
@@ -8,7 +8,7 @@
   "Email": "tchelinux-eventos@gmail.com", 
   "Website": "https://tchelinux.org", 
   "Github": "https://github.com/tchelinux", 
-  "Linkedin": "hhttps://www.linkedin.com/groups/771307", 
+  "Linkedin": "https://www.linkedin.com/groups/771307", 
   "Twitter": "https://twitter.com/tchelinux", 
   "Mastodon": "https://mastodon.social/@tchelinux",
   "Youtube": "https://youtube.com/tchelinux",

--- a/template.json
+++ b/template.json
@@ -8,7 +8,7 @@
   "Email": "tchelinux-eventos@gmail.com", 
   "Website": "https://tchelinux.org", 
   "Github": "https://github.com/tchelinux", 
-  "Linkedin": "hhttps://www.linkedin.com/groups/771307", 
+  "Linkedin": "https://www.linkedin.com/groups/771307", 
   "Twitter": "https://twitter.com/tchelinux", 
   "Mastodon": "https://mastodon.social/@tchelinux",
   "Youtube": "https://youtube.com/tchelinux",


### PR DESCRIPTION
Esta modificação corrige um erro de digitação nos links do LinkedIn do perfil do grupo e do template.